### PR TITLE
Decouple gateway bot and rest bot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 aiohttp ~= 3.8.1
-alluka ~= 0.1.1
-asyncpg ~= 0.25.0
+alluka ~= 0.1.2
+asyncpg ~= 0.26.0
 beautifulsoup4 ~= 4.11.1
-hikari ~= 2.0.0.dev109
-hikari-tanjun ~= 2.5.2a1
+# hikari ~= 2.0.0.dev109
+git+https://github.com/davfsa/hikari@task/new-lifetime-test
+hikari-tanjun ~= 2.5.3a1
 js2py ~= 0.71
-typing_extensions ~= 4.2.0
+typing_extensions ~= 4.3.0
 uvloop ~= 0.16.0; os_name != 'nt'
 yarl ~= 1.7.2

--- a/ritsu/__main__.py
+++ b/ritsu/__main__.py
@@ -2,11 +2,22 @@
 
 """The main code for the new Ritsu bot written in hikari"""
 
+import asyncio
 from ritsu.start import start_bot
 
 if __name__ != "__main__":
     raise ImportError("This script isn't intended to be imported!")
 
-bot, activity = start_bot()
 
-bot.run(activity=activity)
+async def main() -> None:
+    """The main async function to start the bot"""
+    await bot.start()
+    async with client:
+        await bot.join()
+
+bot, client = start_bot()
+loop = asyncio.get_event_loop_policy().get_event_loop()
+try:
+    loop.run_until_complete(main())
+except KeyboardInterrupt:
+    loop.run_until_complete(bot.close())

--- a/ritsu/handlers/common.py
+++ b/ritsu/handlers/common.py
@@ -1,0 +1,24 @@
+"""Handlers for component interactions"""
+
+from typing import Awaitable
+
+import alluka
+import hikari
+import tanjun
+
+from hikari.impl.special_endpoints import InteractionMessageBuilder
+
+
+class ComponentInteractionHandler:
+    def __init__(self):
+        pass
+
+    async def pubchem_handler(self):
+        """To handle interactions for messages from Pubchem component"""
+
+    async def __call__(
+        self, inter: hikari.ComponentInteraction,
+        bot: alluka.Injected[hikari.RESTAware]
+    ) -> Awaitable[hikari.api.special_endpoints.InteractionResponseBuilder]:
+        """To be used when interaction handler is called"""
+        return bot.rest.create_interaction_response()

--- a/ritsu/handlers/pubchem.py
+++ b/ritsu/handlers/pubchem.py
@@ -15,7 +15,7 @@ hooks = tanjun.SlashHooks()
 @hooks.with_on_success
 async def handle_inters(
     ctx: tanjun.abc.SlashContext,
-    bot: alluka.Injected[hikari.GatewayBot],
+    bot: alluka.Injected[hikari.RESTAware],
     action_row: hikari.api.ActionRowBuilder = (
         tanjun.cached_inject(gen_action_row)
     )

--- a/ritsu/utils/pubchem.py
+++ b/ritsu/utils/pubchem.py
@@ -63,7 +63,7 @@ def gen_compound_embed(details: dict[str, str | int]) -> hikari.Embed:
 
 
 def gen_action_row(
-    bot: alluka.Injected[hikari.GatewayBot]
+    bot: alluka.Injected[hikari.RESTBot]
 ) -> hikari.api.ActionRowBuilder:
     """To generate a tuple of action rows to be cached for later use"""
 

--- a/ritsu/utils/subsplease.py
+++ b/ritsu/utils/subsplease.py
@@ -41,7 +41,7 @@ def gen_schedule_embed(schedule: ItemsView, day_of_week: str) -> hikari.Embed:
 
 
 def gen_action_row(
-    bot: alluka.Injected[hikari.GatewayBot]
+    bot: alluka.Injected[hikari.RESTAware]
 ) -> hikari.api.ActionRowBuilder:
     """To generate a cached ActionRowBuilder to reuse for other commands"""
 

--- a/ritsu/utils/wiki.py
+++ b/ritsu/utils/wiki.py
@@ -47,7 +47,7 @@ async def fetch_article(
 async def send_initial_resp(
     ctx: tanjun.abc.SlashContext,
     search_term: str,
-    bot: alluka.Injected[hikari.GatewayBot],
+    bot: alluka.Injected[hikari.RESTAware],
     injector: alluka.Injected[alluka.Client],
     fandom_name: str = "en"
 ) -> None:
@@ -59,7 +59,8 @@ async def send_initial_resp(
         ctx.command.name,
         fandom_name
     )
-    action_row = None
+    _actionRowT = hikari.api.ActionRowBuilder | hikari.UndefinedType
+    action_row: _actionRowT = hikari.UNDEFINED
     if len(titles) - 1:
         action_row: hikari.api.ActionRowBuilder = bot.rest.build_action_row()
         select_menu: hikari.api.SelectMenuBuilder = (


### PR DESCRIPTION
It's probably better to use a RESTBot with an interaction server than use a full on bot with websockets running 24/7.

Though, with that being said, this would call for a refactor again as there are no gateway events in a RESTBot (as there's no gateway 🙃)

This combined with a RESTApp for scheduled webhooks (for anime notifs/reminders and stuff) would make for a nice and fast bot (considering that I don't have any intention to make this bot moderate a server)

Even if I need to use moderation tools, probably a gateway can be kept on just to monitor messages I guess...